### PR TITLE
Market Interval has start and end, and adds Market Prices

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -115,6 +115,16 @@ paths:
             minimum: 1
             maximum: 8760
             default: 1
+        - name: start
+          in: query
+          description: |
+            Start time of the interval in RFC3339 (URI escaped). If not provided, it is computed using the
+            hours parameter.
+          required: false
+          schema:
+            type: string
+          example: "2018-05-14T00%3A00%3A00Z"
+        - $ref: '#/components/parameters/interval-end'
       responses:
         '200':
           description: A list of markets with price and volume information for a currency
@@ -130,6 +140,53 @@ paths:
               example: "bitfinex,EUR,5107055.26765,9484.34395,05/03/2018 15:00:00,9671.60953,05/03/2018 20:31:24"
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+  /markets/prices:
+    get:
+      summary: Market Prices
+      operationId: getMarketPrices
+      description: |
+        The market prices endpoint returns prices in USD for the last trade in each market with the given base
+        currency.
+      parameters:
+        - name: currency
+          in: query
+          description: Nomics Currency ID of the desired base currency
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of markets with their price
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    exchange:
+                      type: string
+                      description: Nomics ID of the exchange
+                    quote:
+                      type: string
+                      description: Nomics ID of the quote currency
+                    price:
+                      type: string
+                      description: Price in USD of the most recent trade
+                    timestamp:
+                      type: string
+                      description: RFC3339 Timestamp of the most recent trade
+                  example:
+                    exchange: "bitfinex"
+                    quote: "USD"
+                    price: "7419.69255"
+                    timestamp: "2018-06-05T13:23:18.345Z"
+            text/csv:
+              schema:
+                type: string
+              example: "bitfinex,USD,7419.69255,06/05/2018 13:23:18"
+        '401':
+           $ref: '#/components/responses/UnauthorizedError'
   /prices:
     get:
       summary: Prices


### PR DESCRIPTION
@amy-r this adds start and end to market interval so that we can grab the "previous" day/week/month/year for currency page to compute volume change.

Additionally, markets interval no longer includes most recent prices. The close price is the close price of the candle returned.

To get most recent prices, there's now a Market Prices endpoint that just has prices. This way, we only need to update market interval once every minute or so, and we can update Market Prices every 10 seconds for the freshest prices.

I'll implement this in your PR on the nomics repo so you'll have all the data for the stats tab and also I'll update the markets tab to use the market prices.