### PR TITLE
order snapshot exclude list

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -1282,27 +1282,12 @@ paths:
         
         CSV format is: `timestamp,bidPrice,bidAmount,askPrice,askAmount`
 
-        **Order books are currently only available for the following exchange IDs:**
+        **Order books are currently not available for the following exchange IDs:**
 
-        * `acx`
-        * `binance`
-        * `bitfinex`
-        * `bitibu`
-        * `bitmex` Bitmex order books are available, but only by request. Bitmex is a futures exchange and we do not include its trade data with the rest of our data set.
-        * `bittrex`
-        * `cobinhood`
-        * `coinex`
-        * `ethfinex`
-        * `gdax`
-        * `gemini`
-        * `huobipro`
-        * `kraken`
-        * `okcoinusd`
-        * `okex`
-        * `poloniex`
-        * `uex`
-        * `upbit`
-        * `zb`
+        * `bitflyer`
+        * `hitbtc`
+
+        Order books are available for Bitmex, but only by request. Bitmex is a futures exchange and we do not include its trade data with the rest of our data set.
       parameters:
         - $ref: '#/components/parameters/exchange'
         - $ref: '#/components/parameters/market'


### PR DESCRIPTION
Switch to an exclude list instead of an include list. All new exchanges come with books, and only two remain without books.

/cc @claycollins 