### PR TITLE
spec: clarify that the max per-page value is 100

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -3256,7 +3256,7 @@ components:
         Paginated responses include an additional response header,
         `X-Pagination-Total-Items`, which represents the total number
         of items available after all the request filters have been
-        applied.
+        applied.  Must be between `1` and `100` (inclusive).
       required: false
       schema:
         type: integer


### PR DESCRIPTION
I'd specified a max in the "schema" section, but it looks like that
isn't shown anywhere in the UI.